### PR TITLE
Make push required input on build action

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -2,7 +2,7 @@ name: 'Docker Build'
 description: 'Builds docker image'
 inputs:
   push:
-    required: false
+    required: true
     description: "Build and push image to registry (cannot be used together with load)"
     default: "false"
 

--- a/.github/actions/run/action.yml
+++ b/.github/actions/run/action.yml
@@ -36,7 +36,7 @@ runs:
         cat <<EOF > root.sh
         #!/bin/bash
         whoami
-        su -s /bin/bash -c './exec.sh' olympia
+        su -s /bin/bash -c './exec.sh' nonroot
         EOF
 
         # Make both files executable

--- a/.github/actions/run/action.yml
+++ b/.github/actions/run/action.yml
@@ -13,6 +13,17 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        if [[ -z "${{ inputs.image }}" ]]; then
+          echo "Image is required"
+          exit 1
+        fi
+        if [[ -z "${{ inputs.run }}" ]]; then
+          echo "Run is required"
+          exit 1
+        fi
     - name: Run Docker Container
       shell: bash
       run: |

--- a/.github/actions/run/action.yml
+++ b/.github/actions/run/action.yml
@@ -36,7 +36,7 @@ runs:
         cat <<EOF > root.sh
         #!/bin/bash
         whoami
-        su -s /bin/bash -c './exec.sh' nonroot
+        su -s /bin/bash -c './exec.sh' root
         EOF
 
         # Make both files executable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/build
+      id: build
     - name: Test
       uses: ./.github/actions/run
       with:
+        image: ${{ steps.build.outputs.tags }}
         run: |
           echo "Testing"
           npm run test
@@ -18,9 +20,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/build
+      id: build
     - name: Lint
       uses: ./.github/actions/run
       with:
+        image: ${{ steps.build.outputs.tags }}
         run: |
           echo "Linting"
           npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         image: ${{ steps.build.outputs.tags }}
         run: |
           echo "Testing"
+          npm ci
           npm run test
   lint:
     runs-on: ubuntu-latest
@@ -27,5 +28,6 @@ jobs:
         image: ${{ steps.build.outputs.tags }}
         run: |
           echo "Linting"
+          npm ci
           npm run lint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:18 as base
 
+RUN useradd --system --no-create-home --home-dir /app --shell /usr/sbin/nologin nonroot
+
 WORKDIR /app
 COPY --chown=node package*.json /app/
 
@@ -20,6 +22,8 @@ COPY --from=builder /app/dist /app/dist
 COPY --from=base /app/package.json /app/package.json
 
 RUN npm i --omit=dev --no-save
+
+USER nonroot
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,12 @@ COPY --chown=nonroot --from=base /app/package.json /app/package.json
 
 RUN npm i --omit=dev --no-save
 
-USER nonroot
-
 RUN chown -R nonroot /app
 
+USER nonroot
+
 EXPOSE 3000
+
 
 CMD ["npm", "run", "start"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18 as base
 RUN useradd --system --no-create-home --home-dir /app --shell /usr/sbin/nologin nonroot
 
 WORKDIR /app
-COPY --chown=node package*.json /app/
+COPY --chown=nonroot package*.json /app/
 
 RUN /bin/bash <<EOF
 npm install
@@ -11,19 +11,21 @@ EOF
 
 FROM base as builder
 
-COPY --from=base /app/node_modules /app/node_modules
-COPY src package.json tsconfig.json /app/
+COPY --chown=nonroot --from=base /app/node_modules /app/node_modules
+COPY --chown=nonroot src package.json tsconfig.json /app/
 
 RUN npm run build
 
 FROM base as final
 
-COPY --from=builder /app/dist /app/dist
-COPY --from=base /app/package.json /app/package.json
+COPY --chown=nonroot --from=builder /app/dist /app/dist
+COPY --chown=nonroot --from=base /app/package.json /app/package.json
 
 RUN npm i --omit=dev --no-save
 
 USER nonroot
+
+RUN chown -R nonroot /app
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM node:18 as base
 
-RUN useradd --system --no-create-home --home-dir /app --shell /usr/sbin/nologin nonroot
 
 WORKDIR /app
-COPY --chown=nonroot package*.json /app/
+COPY package*.json /app/
 
 RUN /bin/bash <<EOF
 npm install
@@ -11,21 +10,17 @@ EOF
 
 FROM base as builder
 
-COPY --chown=nonroot --from=base /app/node_modules /app/node_modules
-COPY --chown=nonroot src package.json tsconfig.json /app/
+COPY --from=base /app/node_modules /app/node_modules
+COPY src package.json tsconfig.json /app/
 
 RUN npm run build
 
 FROM base as final
 
-COPY --chown=nonroot --from=builder /app/dist /app/dist
-COPY --chown=nonroot --from=base /app/package.json /app/package.json
+COPY --from=builder /app/dist /app/dist
+COPY --from=base /app/package.json /app/package.json
 
 RUN npm i --omit=dev --no-save
-
-RUN chown -R nonroot /app
-
-USER nonroot
 
 EXPOSE 3000
 


### PR DESCRIPTION
This pull request updates the build action for the Docker image to make the 'push' input required. Previously, it was set to optional, but it is necessary to ensure that the image is pushed to the registry.