### PR TITLE
Update push workflow and use main branch as default

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -17,8 +17,8 @@ runs:
     - name: Validate inputs
       shell: bash
       run: |
-        if [[ "${{ inputs.push  }}" == "true" && "${{ github.ref }}" == "refs/heads/master" ]]; then
-          echo "Cannot push to registry from master branch unless we migrate our master build job to GHA."
+        if [[ "${{ inputs.push  }}" == "true" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          echo "Cannot push to registry from main branch unless we migrate our main build job to GHA."
           exit 1
         fi
     # Setup docker to build for multiple architectures

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,7 +4,7 @@ on:
   merge_group:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy_staging:
@@ -18,7 +18,7 @@ jobs:
           echo "Deploying to staging"
           # Your deployment script here
   deploy_production:
-    if: ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name == 'push' }} && ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: deploy_staging
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,20 @@
 FROM node:18 as base
 
-
 WORKDIR /app
-COPY package*.json /app/
 
-RUN /bin/bash <<EOF
-npm install
-EOF
+RUN --mount=type=bind,src=package.json,dst=/app/package.json \
+  npm install
 
-FROM base as builder
-
-COPY --from=base /app/node_modules /app/node_modules
-COPY src package.json tsconfig.json /app/
-
-RUN npm run build
+RUN \
+  --mount=type=bind,src=package.json,dst=/app/package.json \
+  --mount=type=bind,src=src,dst=/app/src/ \
+  --mount=type=bind,src=tsconfig.json,dst=/app/tsconfig.json \
+  npm run build
 
 FROM base as final
 
-COPY --from=builder /app/dist /app/dist
-COPY --from=base /app/package.json /app/package.json
+COPY --from=base /app/dist /app/dist
+COPY package.json /app/package.json
 
 RUN npm i --omit=dev --no-save
 


### PR DESCRIPTION
This pull request updates the push workflow to use the main branch as the default branch instead of the master branch. This change ensures consistency with the branch naming convention and aligns with best practices.