### PR TITLE
Use GraphQL API to retrieve pull request links

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -68,13 +68,29 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.gh_token }}
       run: |
-        prs=$(gh api \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls)
+        data=$(gh api graphql \
+          -F owner='${{ github.repository_owner }}' \
+          -F name='${{ github.event.repository.name }}' \
+          -F ref='${{ github.sha }}' \
+          -F query='query($name: String!, $owner: String!, $ref: GitObjectID!) {
+              repository(owner: $owner, name: $name) {
+                object(oid: $ref) {
+                  ...on Commit {
+                    associatedPullRequests(first: 10) {
+                      nodes {
+                        number
+                      }
+                    }
+                  }
+                }
+              }
+            }')
+
+        prs=$(echo $data | jq -r '.data.repository.object.associatedPullRequests.nodes[].number')
 
         echo "prs=$prs" >> $GITHUB_OUTPUT
         echo "prs $prs"
+        echo "data $data"
 
     - name: Get ther run URL
       id: run
@@ -96,7 +112,7 @@ runs:
         [View the run](${{ steps.run.outputs.url }})
         EOF
 
-        for pr in $(echo '${{ steps.prs.outputs.prs }}' | jq -r '.[].number'); do
+        for pr in $(echo '${{ steps.prs.outputs.prs }}'); do
           gh api \
             --method POST \
             -H "Accept: application/vnd.github.v3+json" \

--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -33,5 +33,3 @@ jobs:
           fly_token: ${{ secrets.FLY_TOKEN }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: ./.github/actions/link


### PR DESCRIPTION
This pull request updates the code to use the GraphQL API instead of the REST API to retrieve pull request links. This change improves performance and efficiency.