### PR TITLE
Add single test status job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,19 @@ jobs:
           echo "Testing"
           npm ci
           npm run test -- --shard=${{ matrix.group }}/5
+
+  test-status:
+    runs-on: ubuntu-20.04
+    needs: [test]
+    if: always()
+    steps:
+      - name: All tests passed
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+
   lint:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request adds a new job called "test-status" that checks if all tests have passed. If all tests have passed, the job will exit with a status of 0. If any tests have failed, the job will exit with a status of 1. This job will run after the "test" job and will be triggered regardless of the outcome of the "test" job.